### PR TITLE
Fix domain lookup by UUID

### DIFF
--- a/spice-record
+++ b/spice-record
@@ -504,7 +504,7 @@ def lookup_domain(conn, key):
 
         # Try UUID
         try:
-            return conn.lookupByUUID(UUID(key))
+            return conn.lookupByUUID(UUID(key).bytes)
         except ValueError:
             pass
 


### PR DESCRIPTION
Give bytes to `lookupByUUID` instead of an UUID object.