### PR TITLE
Fix non-fd spice session opening

### DIFF
--- a/spice-record
+++ b/spice-record
@@ -169,9 +169,9 @@ class SpiceRecorder(GObject.GObject):
         logging.debug('openGraphicsFD(0) returned %d', fd)
         return fd
 
-    def _create_spice_session(self):
+    def _create_spice_session(self, conf):
         assert not self._spice_session
-        self._spice_session = SpiceClientGLib.Session(read_only=True)
+        self._spice_session = SpiceClientGLib.Session(read_only=True, **conf)
         SpiceClientGLib.set_session_option(self._spice_session)
 
         GObject.GObject.connect(self._spice_session, "channel-new",
@@ -342,18 +342,17 @@ class SpiceRecorder(GObject.GObject):
         self._spice_session.open_fd(fd)
 
     def _open_host(self):
-        coninfo = domain_extract_connect_info(dom)
-
-        self._create_spice_session()
-
+        coninfo = domain_extract_connect_info(self._vm)
         logging.debug("Spice connecting to host=%s port=%s tlsport=%s",
             coninfo.ghost, coninfo.gport, coninfo.gtlsport)
-        self._spice_session.set_property("host", str(coninfo.ghost))
-        if port:
-            self._spice_session.set_property("port", str(coninfo.gport))
-        if tlsport:
-            self._spice_session.set_property("tls-port", str(coninfo.gtlsport))
+        conf = {
+            "host": coninfo.ghost,
+            "port": coninfo.gport,
+            "tls_port": coninfo.gtlsport,
+            "password": coninfo.gpasswd,
+        }
 
+        self._create_spice_session(conf)
         self._spice_session.connect()
 
     def open(self):
@@ -521,7 +520,7 @@ def domain_extract_connect_info(domain):
     # See
     #   virt_viewer_extract_connect_info()
     #   virt_viewer_app_set_connect_info()
-    tree = ET.fromstring(domain.XMLDesc())
+    tree = ET.fromstring(domain.XMLDesc(libvirt.VIR_DOMAIN_XML_SECURE))
     ET.dump(tree)
 
     gfx = tree.find('devices/graphics')
@@ -537,6 +536,7 @@ def domain_extract_connect_info(domain):
     o.gtlsport = gfx.get('tlsport')
     o.ghost = gfx.get('listen')
     o.unixsock = gfx.get('socket')
+    o.gpasswd = gfx.get('passwd')
 
     if o.ghost and o.gport:
         logging.info('Guest graphics address is {}:{}'.format(o.ghost, o.gport))


### PR DESCRIPTION
While debugging channel opening issues I tried to use spice-record with
"classic" host session opening. I found that for various reasons this
would never have worked.

Fixes host session opening logic, get and use spice password