### PR TITLE
Fix BrokenPipeError in SpiceRecordWrapper.close()

### DIFF
--- a/spicerecord/wrapper.py
+++ b/spicerecord/wrapper.py
@@ -59,8 +59,12 @@ class SpiceRecordWrapper:
     def stop(self):
         if self.stopped:
             raise Exception("stop() already called")
-        self.p.stdin.write(b'Q\n')
-        self.p.stdin.close()
+        try:
+            self.p.stdin.write(b'Q\n')
+            self.p.stdin.close()
+        except (BrokenPipeError, IOError):
+            # The process has already exited
+            pass
         self.stopped = True
 
     def wait(self):


### PR DESCRIPTION
If `spice-record` exits for whatever reason, the wrapper will get a `BrokenPipeError` when trying to write to the stdin pipe. We simply ignore this error, as we will later check the exit status in `wait()`.