### PR TITLE
Allow using the machine argument as a remote-viewer url, bypass libvirt

### DIFF
--- a/spicerecord/cli.py
+++ b/spicerecord/cli.py
@@ -40,6 +40,7 @@ def lookup_domain(conn, key):
         return conn.lookupByName(key)
 
     except libvirt.libvirtError as err:
+        return None
         if err.get_error_code() != libvirt.VIR_ERR_NO_DOMAIN:
             raise
         raise AppError(str(err))
@@ -106,12 +107,15 @@ def _main():
 
     # Try to get domain
     dom = lookup_domain(conn, args.machine)
-    logging.info('Using domain "%s" (%s)', dom.name(), dom.UUIDString())
+    if dom is None:
+        logging.info('domain not found')
+    else:
+        logging.info('Using domain "%s" (%s)', dom.name(), dom.UUIDString())
 
     if not args.output:
         args.output = unique_filename(dom.name() + '.mp4')
 
-    record.record(args, dom)
+    record.record(args, dom or args.machine)
 
 
 def main():


### PR DESCRIPTION
Tested on url like spice+unix:///run/user/1000/spice-win32.sock

It's not a rework at all, but the fastest way to make it work...

I could make this work `python3 -m spicerecord -r 5 -o test.mp4 spice+unix:///run/user/1000/spice-win32.sock`

Related to https://github.com/JonathonReinhart/spice-record/issues/17

Let me know if it inspires you to rework. Or I can try to do it. Probably all the libvirt-related thing should be in their own file, and record.py only handle spice-protocol?